### PR TITLE
docs: add more troubleshooting docs

### DIFF
--- a/Documentation/Troubleshooting/.pages
+++ b/Documentation/Troubleshooting/.pages
@@ -1,4 +1,5 @@
 nav:
+    - troubleshooting.md
     - ceph-toolbox.md
     - common-issues.md
     - ceph-common-issues.md

--- a/Documentation/Troubleshooting/ceph-common-issues.md
+++ b/Documentation/Troubleshooting/ceph-common-issues.md
@@ -632,3 +632,130 @@ data: {}
 ```
 
 If the ConfigMap exists, remove any keys that you wish to configure through the environment.
+
+
+## CephFS mount issues on Hosts
+
+Make sure you have a (active) Linux kernel of version `4.17` or higher.
+
+!!! tip
+    In general it is recommended to have a very up-to-date version of the Linux kernel, as many improvements have been made to the Ceph kernel drivers in newer kernel versions (`5.x` or higher).
+
+## `HEALTH_WARN 1 large omap objects`
+
+### Issue
+
+```
+HEALTH_WARN 1 large omap objects
+# and/or
+LARGE_OMAP_OBJECTS 1 large omap objects
+```
+
+### Solution
+
+The following command should fix the issue:
+
+```console
+radosgw-admin reshard stale-instances rm
+```
+
+## `MDSs report oversized cache`
+
+### Issue
+
+Ceph health status reports, e.g., `1 MDSs report oversized cache`.
+
+```
+[root@rook-ceph-tools-86d54cbd8d-6ktjh /]# ceph -s
+  cluster:
+    id:     67e1ce27-0405-441e-ad73-724c93b7aac4
+    health: HEALTH_WARN
+            1 MDSs report oversized cache
+[...]
+```
+
+### Solution
+
+You can try to increase the `mds cache memory limit` setting[^1].
+
+!!! tip
+    For Rook Ceph users, you set/increase the memory requests on the CephFilesystem object for the MDS daemons[^2].
+
+[^1]: Report / Source for information regarding this issue has been taken from http://lists.ceph.com/pipermail/ceph-users-ceph.com/2019-December/037633.html
+[^2]: [Rook Ceph Docs v1.7 - Ceph Filesystem CRD - MDS Resources Configuration Settings](https://rook.io/docs/rook/v1.7/ceph-filesystem-crd.html#mds-resources-configuration-settings)
+
+## Find Device OSD is using
+
+### Issue
+
+You need to find out which disk/device is used by an OSD daemon.
+
+**Scenarios**: `smartctl` is showing that the disk should be replaced, disk has already failed, etc.
+
+### Solution
+
+Use the various `ls*` subcommands of `ceph device`.
+
+```console
+$ ceph device --help
+device check-health                                                         Check life expectancy of devices
+device get-health-metrics <devid> [<sample>]                                Show stored device metrics for the device
+device info <devid>                                                         Show information about a device
+device light on|off <devid> [ident|fault] [--force]                         Enable or disable the device light. Default type is `ident`
+'Usage: device
+                                                                             light (on|off) <devid> [ident|fault] [--force]'
+device ls                                                                   Show devices
+device ls-by-daemon <who>                                                   Show devices associated with a daemon
+device ls-by-host <host>                                                    Show devices on a host
+device ls-lights                                                            List currently active device indicator lights
+device monitoring off                                                       Disable device health monitoring
+device monitoring on                                                        Enable device health monitoring
+device predict-life-expectancy <devid>                                      Predict life expectancy with local predictor
+device query-daemon-health-metrics <who>                                    Get device health metrics for a given daemon
+device rm-life-expectancy <devid>                                           Clear predicted device life expectancy
+device scrape-daemon-health-metrics <who>                                   Scrape and store device health metrics for a given daemon
+device scrape-health-metrics [<devid>]                                      Scrape and store device health metrics
+device set-life-expectancy <devid> <from> [<to>]                            Set predicted device life expectancy
+```
+
+The `ceph device` subcommands allow you to do even more things, e.g., turn on the disk light in server chassis.
+Enabling the light for the disk can help the datacenter workers to easily locate the disk and not replacing the wrong disk.
+
+#### Locate Disk of OSD by OSD daemon ID (e.g., OSD 13):
+
+```console
+$ ceph device ls-by-daemon osd.13
+DEVICE                                     HOST:DEV                                           EXPECTED FAILURE
+SAMSUNG_MZVL2512HCJQ-00B00_S1234567890123  HOSTNAME:nvme1n1
+```
+
+#### Show all disks by host (hostname):
+
+```console
+$ ceph device ls-by-host HOSTNAME
+DEVICE                                     HOST:DEV                                           EXPECTED FAILURE
+DEVICE                                     DEV      DAEMONS  EXPECTED FAILURE
+SAMSUNG_MZVL2512HCJQ-00B00_S1234567890123  nvme1n1  osd.5
+SAMSUNG_MZVL2512HCJQ-00B00_S1234567890123  nvme0n1  osd.2
+SAMSUNG_MZVL2512HCJQ-00B00_S1234567890123  nvme2n1  osd.8
+SAMSUNG_MZVL2512HCJQ-00B00_S1234567890123  nvme3n1  osd.13
+```
+
+## CephOSDSlowOps Alerts
+
+### Issue
+
+This can be either a hardware or software issue on multiple levels.
+Either a disk is going bad, e.g., taking long to respond to IO operations, or your kernel has issues interacting with the disk(s)/ disk controller.
+It can also be related to Ceph which is not often and would normally either due to a misconfiguration of Ceph or a weird bug in the Ceph OSD (make sure to check the current issues on [the Ceph tracker](https://tracker.ceph.com/issues/)).
+
+### Things to Try
+
+* Ensure the disk(s) you are using are healthy
+    * Check the SMART values. A bad disks can lock up an application (such as a Ceph OSD) or worse the whole server.
+    * Make sure the connector/ cables between the disk(s) are plugged in correctly, e.g., re-seat disk.
+* Make sure you use the same kernel version on all your machines and/ or find any "abnormality" between the server(s) that encounter this issue with others that don't.
+    * Check your kernel message log, using `dmesg` command.
+* Check your Ceph config for any new additions
+    * Run `ceph config dump` in [the toolbox pod](../Troubleshooting/ceph-toolbox.md).
+    * Check the contents of the [`rook-config-override` ConfigMap](../Storage-Configuration/Advanced/ceph-configuration.md#custom-cephconf-settings).

--- a/Documentation/Troubleshooting/ceph-common-issues.md
+++ b/Documentation/Troubleshooting/ceph-common-issues.md
@@ -682,7 +682,7 @@ You can try to increase the `mds cache memory limit` setting[^1].
     For Rook Ceph users, you set/increase the memory requests on the CephFilesystem object for the MDS daemons[^2].
 
 [^1]: Report / Source for information regarding this issue has been taken from http://lists.ceph.com/pipermail/ceph-users-ceph.com/2019-December/037633.html
-[^2]: [Rook Ceph Docs v1.7 - Ceph Filesystem CRD - MDS Resources Configuration Settings](https://rook.io/docs/rook/v1.7/ceph-filesystem-crd.html#mds-resources-configuration-settings)
+[^2]: [Ceph Filesystem CRD - MDS Resources Configuration Settings](../CRDs/Shared-Filesystem/ceph-filesystem-crd.md#mds-resources-configuration-settings)
 
 ## Find Device OSD is using
 

--- a/Documentation/Troubleshooting/common-issues.md
+++ b/Documentation/Troubleshooting/common-issues.md
@@ -2,38 +2,252 @@
 title: Common Issues
 ---
 
-To help troubleshoot your Koor Storage Distribution clusters, here are some tips on what information will help solve the issues you might be seeing.
 If after trying the suggestions found on this page and the problem is not resolved, the Koor Storage Distribution team is very happy to help you troubleshoot the issues through [GitHub Discussions](https://github.com/koor-tech/koor/discussions).
 
-## Ceph Common Issues
+Be sure to checkout the [Ceph Common Issues](ceph-common-issues.md) and **that [all prerequisites](../Getting-Started/Prerequisites/prerequisites.md) for the storage backend of your choice** are met!
 
-For common issues specific to Ceph, see the [Ceph Common Issues](ceph-common-issues.md) page.
+***
 
-## Troubleshooting Techniques
+## Where did the `rook-discover-*` Pods go after a recent Rook Ceph update?
 
-Kubernetes status and logs are the main resources needed to investigate issues in any Rook cluster.
+A recent change in Rook Ceph has disabled the `rook-discover` DaemonSet by default.
+This behavior is controlled by the `ROOK_ENABLE_DISCOVERY_DAEMON` located in the `operator.yaml` or for Helm users `enableDiscoveryDaemon: (false|true` in your values file. It is a boolean, so `false` or `true`.
 
-## Kubernetes Tools
+### When do you want to have `rook-discover-*` Pods / `ROOK_ENABLE_DISCOVERY_DAEMON: true`?
 
-Kubernetes status is the first line of investigating when something goes wrong with the cluster. Here are a few artifacts that are helpful to gather:
+* You are on **(plain) bare metal** and / or simply have "some disks" installed /attached to your server(s), that you want to use for the Rook Ceph cluster.
+* If your cloud environment / provider does not provide PVCs with `volumeMode: Block`. Ceph requires block devices (Ceph's `filestore` is not available, through Rook, since a bunch of versions as `bluestore` is superior in certain ways).
 
-* Rook pod status:
-  * `kubectl get pod -n <cluster-namespace> -o wide`
-    * e.g., `kubectl get pod -n rook-ceph -o wide`
-* Logs for Rook pods
-  * Logs for the operator: `kubectl logs -n <cluster-namespace> -l app=<storage-backend-operator>`
-    * e.g., `kubectl logs -n rook-ceph -l app=rook-ceph-operator`
-  * Logs for a specific pod: `kubectl logs -n <cluster-namespace> <pod-name>`, or a pod using a label such as mon1: `kubectl logs -n <cluster-namespace> -l <label-matcher>`
-    * e.g., `kubectl logs -n rook-ceph -l mon=a`
-  * Logs on a specific node to find why a PVC is failing to mount:
-    * Connect to the node, then get kubelet logs (if your distro is using systemd): `journalctl -u kubelet`
-  * Pods with multiple containers
-    * For all containers, in order: `kubectl -n <cluster-namespace> logs <pod-name> --all-containers`
-    * For a single container: `kubectl -n <cluster-namespace> logs <pod-name> -c <container-name>`
-  * Logs for pods which are no longer running: `kubectl -n <cluster-namespace> logs --previous <pod-name>`
+## Crash Collector Pods are `Pending` / `ContainerCreating`
 
-Some pods have specialized init containers, so you may need to look at logs for different containers
-within the pod.
+* Check the events of the Crash Collector Pod(s) using `kubectl describe pod POD_NAME`.
+* If the Pod(s) is waiting for a Secret from the Ceph MONs (keyring for each crash collector), you need to wait a bit longer as the Ceph Cluster is probably still being bootsraped / started up.
+* If they are stuck for more than 15-30 minutes, check the Rook Ceph Operator logs if it is stuck in the Ceph Cluster bootstrap / start up procedure.
 
-* `kubectl -n <namespace> logs <pod-name> -c <container-name>`
-* Other Rook artifacts: `kubectl -n <cluster-namespace> get all`
+## No `rook-ceph-mon-*` Pods are running
+
+1. First of all make sure your Kubernetes CNI is working fine! In what feels like 90% of the cases it is network related, e.g., some weird thing with the Kubernetes cluster CNI or other network environment issue.
+    * Can you talk to Cluster Service IPs from every node?
+    * Can you talk to Pod IPs from every node? Even to Pods not on the same node you are testing from?
+    * Check the docs of your CNI, most have a troubleshooting section, e.g., Cilium had some issues from systemd version 245 onwards with `rp_filter`, see here: [rp_filter (default) strict mode breaks certain load balancing cases in kube-proxy-free mode · Issue #13130 · cilium/cilium](https://github.com/cilium/cilium/issues/13130)
+2. Does your environment fit all the prerequisites? Check top of page for the links to some of the prerequisites and / or consult the [Rook.io docs](https://rook.io/).
+3. Check the `rook-ceph-operator` Logs for any warnings, errors, etc.
+
+## Disk(s) / Partition(s) not used for Ceph
+
+* Does section [When do you want to have `rook-discover-*` Pods / `ROOK_ENABLE_DISCOVERY_DAEMON: true`?](#when-do-you-want-to-have-rook-discover--pods--rook_enable_discovery_daemon-true) apply to you? If so, make sure the operator has the discovery daemon enabled in its (Pod) config!
+* Is the disk empty? No leftover partitions on it? Make sure it is either "empty", e.g., nulled by `shred`, `dd` or similar,
+    * To make sure the disk is blank as the Rook docs and I recommend the following commands followed by a reboot of the server:
+        ```
+        DISK="/dev/sdXYZ"
+        sgdisk --zap-all "$DISK"
+        dd if=/dev/zero of="$DISK" bs=1M count=100 oflag=direct,dsync
+        blkdiscard "$DISK"
+        ```
+        Source: [https://rook.io/docs/rook/v1.8/ceph-teardown.html#delete-the-data-on-hosts](https://rook.io/docs/rook/v1.8/ceph-teardown.html#delete-the-data-on-hosts)
+* Was the disk previously used as a Ceph OSD?
+    * Make sure to follow the teardown steps, but make sure to only remove the LVM stuff from that one disk and not from all, see [https://rook.io/docs/rook/v1.8/ceph-teardown.html#delete-the-data-on-hosts](https://rook.io/docs/rook/v1.8/ceph-teardown.html#delete-the-data-on-hosts).
+
+## A Pod can't mount its PersistentVolume after an "unclean" / "undrained" Node shutdown
+
+1. Check the events of the Pod using `kubectl describe pod POD_NAME`.
+2. Check the Node's `dmesg` logs.
+3. Check the kubelet logs for errors related to CSI connectivity and / or make sure the node can reach every other Kubernetes cluster node (at least the Rook Ceph cluster nodes (Ceph Mons, OSDs, MGRs, etc.)).
+4. Checkout the [CSI Common Issues - Rook Docs](https://rook.io/docs/rook/v1.8/ceph-csi-troubleshooting.html).
+
+## Ceph CSI: Provisioning, Mounting, Deletion or something doesn't work
+
+Make sure you have checked out the [CSI Common Issues - Rook Docs](https://rook.io/docs/rook/v1.8/ceph-csi-troubleshooting.html).
+
+If you have some weird kernel and / or kubelet configuration, make sure Ceph CSI's config options in the Rook Ceph Operator config is correctly setup (e.g., `LIB_MODULES_DIR_PATH`, `ROOK_CSI_KUBELET_DIR_PATH`, `AGENT_MOUNTS`).
+
+## Can't run any Ceph Commands in the Toolbox / Ceph Commands timeout
+
+* Are your `rook-ceph-mon-*` Pods all in `Running` state?
+* Does a basic `ceph -s` work?
+* Is your `rook-ceph-mgr-*` Pod(s) running as well?
+* Check the `rook-ceph-mon-*` and `rook-ceph-mgr-*` logs for errors
+* Try deleting the toolbox Pod, "maybe it is just a fluke in your Kubernetes cluster network / CNI.
+    * Also make sure you are using the latest Rook Ceph Toolbox YAML for the Rook Ceph version you are running on, see [Rook Ceph Toolbox Pod not Creating / Stuck section](#rook-ceph-toolbox-pod-not-creating--stuck).
+* In case all these seem to indicate a loss of quorum, e.g., the `rook-ceph-mon-*` talk about `probing` for other mons only, you might need to follow the disaster recovery guide for your Rook Ceph version here: [Rook v1.8 Docs - Ceph Disaster Recovery - Restoring Mon Quorum](https://rook.io/docs/rook/v1.8/ceph-disaster-recovery.html#restoring-mon-quorum).
+
+## A MON Pod is running on a Node which is down
+
+* **DO NOT EDIT THE MON DEPLOYMENT!** A MON Deployment can't just be moved to another node without being failovered by the operator and / or if the MON is running using a PVC for its data.
+* As long as the operator is running the operator should see the mon being down and fail it over after a configurable timeout.
+    * Env var `ROOK_MON_OUT_TIMEOUT`, by default `600s` (10 minutes)
+
+## Remove / Replace a failed disk
+
+Checkout the official Ceph OSD Management guide from Rook here: [Rook v1.8 Docs - Ceph OSD Management](https://rook.io/docs/rook/v1.8/ceph-osd-mgmt.html).
+
+## Rook Ceph Toolbox Pod not Creating / Stuck
+
+* Make sure that you are not using an old version of the Rook Ceph Toolbox, grab the latest manifest here (make sure to switch to the `release-` branch of your Rook release): `https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/toolbox.yaml`
+* The Rook Ceph Toolbox can only fully startup after a Ceph Cluster has at least passed the initial setup by the Rook Ceph operator.
+    * Monitor the Rook Ceph Operator logs for errors.
+* Check the events of the Toolbox Pod using `kubectl describe pod POD_NAME`.
+
+## Ceph OSD Tree: Wrong Device Class
+
+1. Check device class, second column in `ceph osd tree` output.
+2. If you need to change the device class, you first must remove the current one (if it has one set): `ceph osd crush rm-device-class osd.ID`.
+3. Now you can set the device class for the OSD: `ceph osd crush set-device-class CLASS osd.ID`
+   * Default device classes (at the time of writing): `hdd`, `ssd`, `nvme`
+   * Source: [Ceph Docs Latest - CRUSH Maps - Device Classes](https://docs.ceph.com/en/latest/rados/operations/crush-map/#device-classes)
+
+## `HEALTH_WARN: clients are using insecure global_id reclaim` / `HEALTH_WARN: mons are allowing insecure global_id reclaim`
+
+**Source**: https://github.com/rook/rook/issues/7746
+
+> I can confirm this is happening in all clusters, whether a clean install or upgraded cluster, running at least versions: `v14.2.20`, `v15.2.11` or `v16.2.1`.
+>
+> According to the [CVE also previously mentioned](https://docs.ceph.com/en/latest/security/CVE-2021-20288/), there is a security issue where clients need to be upgraded to the releases mentioned. Once all the clients are updated (e.g. the rook daemons and csi driver), a new setting needs to be applied to the cluster that will disable allowing the insecure mode.
+>
+> If you see both these health warnings, then either one of the rook or csi daemons has not been upgraded yet, or some other client is detected on the older version:
+>
+>     health: HEALTH_WARN
+>             client is using insecure global_id reclaim
+>             mon is allowing insecure global_id reclaim
+>
+>
+> If you only see this one warning, then the insecure mode should be disabled:
+>
+>     health: HEALTH_WARN
+>             mon is allowing insecure global_id reclaim
+> To disable the insecure mode from the toolbox after all the clients are upgraded:
+> **Make sure all clients have been upgraded, or else those clients will be blocked after this is set**:
+>
+>     ceph config set mon auth_allow_insecure_global_id_reclaim false
+>
+> Rook could set this flag automatically after the clients have all been updated.
+
+## Check which "Object Store" is used by an OSD
+
+```console
+$ ceph osd metadata 0 | grep osd_objectstore
+"osd_objectstore": "bluestore",
+```
+
+To get a quick overview of the "object stores" (`bluestore`, (don't use it) `filestore`):
+```console
+$ ceph osd count-metadata osd_objectstore
+{
+    "bluestore": 6
+}
+```
+
+## PersistentVolumeClaims / PersistentVolumes are not Resized
+
+* Make sure the Ceph CSI driver for the storage (block or filesystem) is running (check the logs if you are unsure as well).
+* Check if you use a StorageClass that has `allowVolumeExpansion: false`:
+    ```console
+    $ kubectl get storageclasses.storage.k8s.io
+    NAME              PROVISIONER                     RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
+    rook-ceph-block   rook-ceph.rbd.csi.ceph.com      Retain          Immediate           false                  3d21h
+    rook-ceph-fs      rook-ceph.cephfs.csi.ceph.com   Retain          Immediate           true                   3d21h
+    ```
+* To fix this simply set `allowVolumeExpansion: true` in the `StorageClass`. Below is a `StorageClass` with this option set, it is at the top level of the object (not in `.spec` or similar):
+    ```yaml hl_lines="1"
+    allowVolumeExpansion: true
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: rook-ceph-block
+    parameters:
+      clusterID: rook-ceph
+      csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+      [...]
+      imageFeatures: layering
+      imageFormat: "2"
+      pool: replicapool
+    provisioner: rook-ceph.rbd.csi.ceph.com
+    reclaimPolicy: Retain
+    volumeBindingMode: Immediate
+    ```
+
+## `[...] failed to retrieve servicemonitor. servicemonitors.monitoring.coreos.com "rook-ceph-mgr" is forbidden: [...]`
+
+You have the Prometheus Operator installed in your Kubernetes cluster, but have not applied the RBAC necessary for the Rook Ceph Operator to be able to create the monitoring objects.
+
+To rectify this, you can run the following command and / or add the file to your deployment system:
+
+```console
+kubectl apply -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/monitoring/rbac.yaml
+```
+
+(Original file located at: [https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/monitoring/rbac.yaml](https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/monitoring/rbac.yaml))
+
+## `[...] failed to reconcile cluster "rook-ceph": [...] failed to create servicemonitor. the server could not find the requested resource (post servicemonitors.monitoring.coreos.com)`
+
+This normally means that you don't have the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) installed in your Kubernetes cluster. It is required for `.spec.monitoring.enabled: true` in the CephCluster object to work (the operator to be able to create the `ServiceMonitor` object to enable monitoring).
+
+For the [Rook Ceph - Prometheus Monitoring Setup Steps](https://rook.io/docs/rook/v1.8/ceph-monitoring.html#prometheus-alerts) check the link.
+
+### Solution A: Disable Monitoring in CephCluster
+
+Set `.spec.monitoring.enabled` to `false` in your CephCluster object / yaml (and apply it).
+
+### Solution B: Install Prometheus Operator
+
+If you want to use Prometheus for monitoring your applications and in this case also Rook Ceph Cluster easily in Kubernetes, make sure to install the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator).
+
+Checkout the [Prometheus Operator - Getting Started Guide](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md).
+
+## `unable to get monitor info from DNS SRV with service name: ceph-mon` / Can't run `ceph` and `rbd` commands in the Rook Ceph XYZ Pod
+
+You are only supposed to run `ceph`, `rbd`, `radosgw-admin`, etc., commands in the **Rook Ceph Toolbox / Tools Pod**.
+
+Regarding the Rook Ceph Toolbox Pod checkout the Rook documentation here: [Rook Ceph Docs - Ceph Toolbox](https://rook.io/docs/rook/v1.8/ceph-toolbox.html).
+
+### Quick Command to Rook Ceph Toolbox Pod
+
+This requires you to have the Rook Ceph Toolbox deployed, see [Rook Ceph Docs - Ceph Toolbox](https://rook.io/docs/rook/v1.8/ceph-toolbox.html) for more information.
+
+```console
+kubectl -n rook-ceph exec -it $(kubectl -n rook-ceph get pod -l "app=rook-ceph-tools" -o jsonpath='{.items[0].metadata.name}') -- bash
+```
+
+## `OSD id X != my id Y` - OSD Crash
+
+1. Exec into a working Ceph OSD on that host `kubectl exec -n rook-ceph -it OSD_POD_NAME -- bash` (`ceph-bluestore-tool` command is needed), run the following commands:
+    1. Run `lsblk` to see all disks of the host.
+    2. For every disks, run:
+        1. Run `ceph-bluestore-tool show-label --dev=/dev/sdX` (note down the OSD ID (`whoami` field in the JSON output) and which disk the OSD is on (example: `OSD 11 /dev/sda`).
+2. The `rook-ceph-osd-...` deployment needs to be updated with the new/ correct device path. The `ROOK_BLOCK_PATH` environment variable must have the correct device path (there are two occurrences, in the `containers:` and in `initContainers:` list).
+3. After a few seconds / minutes the OSD should show up as `up` in the `ceph osd tree` output (the command can be run in the `rook-ceph-tools` Pod). If you have scaled down the OSD Deployment, make sure to scale it up to `1` again (`kubectl scale -n rook-ceph deployment --replicas=1 rook-ceph-osd...`)
+
+## `_read_bdev_label failed to open /var/lib/ceph/osd/ceph-1/block: (13) Permission denied`
+
+### Issue
+
+* OSD Pod is not starting with logs about the "ceph osd block device" and "permission denied"
+
+### Solution: Do you have the `ceph` package(s) installed on the host and / or a user/group named `ceph`?
+
+This can potentially mess with the owner/group of the ceph osd block device, as described in [GitHub rook/rook Issue 7519 "OSD pod permissions broken, unable to open OSD superblock after node restart"](https://github.com/rook/rook/issues/7519#issuecomment-922263364).
+
+You can either change the user and group ID of the `ceph` user on the host to the one inside the `ceph/ceph` image that your Rook Ceph cluster is running right now (CephCluster object `.spec.cephVersion.image`).
+
+```console
+$ kubectl get -n rook-ceph cephclusters.ceph.rook.io rook-ceph -o yaml
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+[...]
+  name: rook-ceph
+  namespace: rook-ceph
+[...]
+spec:
+  cephVersion:
+    image: quay.io/ceph/ceph:v16.2.6-20210927
+[...]
+```
+
+Depending your hosts, you might not need to even have the `ceph` packages installed. If you are using Rook Ceph, you normally don't need any ceph related packages on the hosts.
+
+Should this have not fixed your issue, you might be running into some other permission issue. If your hosts are using a Linux distribution that uses SELinux, you might need to follow these steps to re-configure the Rook Ceph operator: [Rook Ceph Docs - OpenShift Special Configuration Guide](https://rook.io/docs/rook/v1.8/ceph-openshift.html#rook-settings).
+
+***
+
+Should this page not have yielded you a solution, checkout the [Ceph Common Issues](ceph-common-issues.md) doc as well.

--- a/Documentation/Troubleshooting/common-issues.md
+++ b/Documentation/Troubleshooting/common-issues.md
@@ -4,7 +4,7 @@ title: Common Issues
 
 If after trying the suggestions found on this page and the problem is not resolved, the Koor Storage Distribution team is very happy to help you troubleshoot the issues through [GitHub Discussions](https://github.com/koor-tech/koor/discussions).
 
-Be sure to checkout the [Ceph Common Issues](ceph-common-issues.md) and **that [all prerequisites](../Getting-Started/Prerequisites/prerequisites.md) for the storage backend of your choice** are met!
+Be sure to checkout the [Ceph Common Issues](ceph-common-issues.md) and **that [all prerequisites](../Getting-Started/Prerequisites/prerequisites.md) for the storage backend of your choice** are met.
 
 ***
 
@@ -30,7 +30,7 @@ This behavior is controlled by the `ROOK_ENABLE_DISCOVERY_DAEMON` located in the
     * Can you talk to Cluster Service IPs from every node?
     * Can you talk to Pod IPs from every node? Even to Pods not on the same node you are testing from?
     * Check the docs of your CNI, most have a troubleshooting section, e.g., Cilium had some issues from systemd version 245 onwards with `rp_filter`, see here: [rp_filter (default) strict mode breaks certain load balancing cases in kube-proxy-free mode · Issue #13130 · cilium/cilium](https://github.com/cilium/cilium/issues/13130)
-2. Does your environment fit all the prerequisites? Check top of page for the links to some of the prerequisites and / or consult the [Rook.io docs](https://rook.io/).
+2. Does your environment fit all the prerequisites? Check top of page for the links to some of the prerequisites and / or consult the [Koor docs](../Getting-Started/intro.md).
 3. Check the `rook-ceph-operator` Logs for any warnings, errors, etc.
 
 ## Disk(s) / Partition(s) not used for Ceph
@@ -44,20 +44,20 @@ This behavior is controlled by the `ROOK_ENABLE_DISCOVERY_DAEMON` located in the
         dd if=/dev/zero of="$DISK" bs=1M count=100 oflag=direct,dsync
         blkdiscard "$DISK"
         ```
-        Source: [https://rook.io/docs/rook/v1.8/ceph-teardown.html#delete-the-data-on-hosts](https://rook.io/docs/rook/v1.8/ceph-teardown.html#delete-the-data-on-hosts)
+        Source: [Koor Storage Cluster Cleanup - Delete the data on hosts](../Storage-Configuration/ceph-teardown.md#delete-the-data-on-hosts)
 * Was the disk previously used as a Ceph OSD?
-    * Make sure to follow the teardown steps, but make sure to only remove the LVM stuff from that one disk and not from all, see [https://rook.io/docs/rook/v1.8/ceph-teardown.html#delete-the-data-on-hosts](https://rook.io/docs/rook/v1.8/ceph-teardown.html#delete-the-data-on-hosts).
+    * Make sure to follow the teardown steps, but make sure to only remove the LVM stuff from that one disk and not from all, see [Koor Storage Cluster Cleanup - Delete the data on hosts](../Storage-Configuration/ceph-teardown.md#delete-the-data-on-hosts).
 
 ## A Pod can't mount its PersistentVolume after an "unclean" / "undrained" Node shutdown
 
 1. Check the events of the Pod using `kubectl describe pod POD_NAME`.
 2. Check the Node's `dmesg` logs.
 3. Check the kubelet logs for errors related to CSI connectivity and / or make sure the node can reach every other Kubernetes cluster node (at least the Rook Ceph cluster nodes (Ceph Mons, OSDs, MGRs, etc.)).
-4. Checkout the [CSI Common Issues - Rook Docs](https://rook.io/docs/rook/v1.8/ceph-csi-troubleshooting.html).
+4. Checkout the [CSI Common Issues - Koor Docs](ceph-csi-common-issues.md).
 
 ## Ceph CSI: Provisioning, Mounting, Deletion or something doesn't work
 
-Make sure you have checked out the [CSI Common Issues - Rook Docs](https://rook.io/docs/rook/v1.8/ceph-csi-troubleshooting.html).
+Make sure you have checked out the [CSI Common Issues - Koor Docs](ceph-csi-common-issues.md).
 
 If you have some weird kernel and / or kubelet configuration, make sure Ceph CSI's config options in the Rook Ceph Operator config is correctly setup (e.g., `LIB_MODULES_DIR_PATH`, `ROOK_CSI_KUBELET_DIR_PATH`, `AGENT_MOUNTS`).
 
@@ -69,7 +69,7 @@ If you have some weird kernel and / or kubelet configuration, make sure Ceph CSI
 * Check the `rook-ceph-mon-*` and `rook-ceph-mgr-*` logs for errors
 * Try deleting the toolbox Pod, "maybe it is just a fluke in your Kubernetes cluster network / CNI.
     * Also make sure you are using the latest Rook Ceph Toolbox YAML for the Rook Ceph version you are running on, see [Rook Ceph Toolbox Pod not Creating / Stuck section](#rook-ceph-toolbox-pod-not-creating--stuck).
-* In case all these seem to indicate a loss of quorum, e.g., the `rook-ceph-mon-*` talk about `probing` for other mons only, you might need to follow the disaster recovery guide for your Rook Ceph version here: [Rook v1.8 Docs - Ceph Disaster Recovery - Restoring Mon Quorum](https://rook.io/docs/rook/v1.8/ceph-disaster-recovery.html#restoring-mon-quorum).
+* In case all these seem to indicate a loss of quorum, e.g., the `rook-ceph-mon-*` talk about `probing` for other mons only, you might need to follow the disaster recovery guide for your Rook Ceph version here: [Rook Ceph Disaster Recovery - Restoring Mon Quorum](disaster-recovery.md#restoring-mon-quorum).
 
 ## A MON Pod is running on a Node which is down
 
@@ -79,7 +79,7 @@ If you have some weird kernel and / or kubelet configuration, make sure Ceph CSI
 
 ## Remove / Replace a failed disk
 
-Checkout the official Ceph OSD Management guide from Rook here: [Rook v1.8 Docs - Ceph OSD Management](https://rook.io/docs/rook/v1.8/ceph-osd-mgmt.html).
+Checkout the official Ceph OSD Management guide from Rook here: [Rook Ceph OSD Management Docs](../Storage-Configuration/Advanced/ceph-osd-mgmt.md).
 
 ## Rook Ceph Toolbox Pod not Creating / Stuck
 
@@ -182,7 +182,7 @@ kubectl apply -f https://raw.githubusercontent.com/rook/rook/master/cluster/exam
 
 This normally means that you don't have the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) installed in your Kubernetes cluster. It is required for `.spec.monitoring.enabled: true` in the CephCluster object to work (the operator to be able to create the `ServiceMonitor` object to enable monitoring).
 
-For the [Rook Ceph - Prometheus Monitoring Setup Steps](https://rook.io/docs/rook/v1.8/ceph-monitoring.html#prometheus-alerts) check the link.
+For the [Rook Ceph Prometheus Monitoring Setup Steps](../Storage-Configuration/Monitoring/ceph-monitoring.md#prometheus-alerts) check the link.
 
 ### Solution A: Disable Monitoring in CephCluster
 
@@ -198,11 +198,11 @@ Checkout the [Prometheus Operator - Getting Started Guide](https://github.com/pr
 
 You are only supposed to run `ceph`, `rbd`, `radosgw-admin`, etc., commands in the **Rook Ceph Toolbox / Tools Pod**.
 
-Regarding the Rook Ceph Toolbox Pod checkout the Rook documentation here: [Rook Ceph Docs - Ceph Toolbox](https://rook.io/docs/rook/v1.8/ceph-toolbox.html).
+Regarding the Rook Ceph Toolbox Pod checkout the Rook documentation here: [Ceph Toolbox](ceph-toolbox.md).
 
 ### Quick Command to Rook Ceph Toolbox Pod
 
-This requires you to have the Rook Ceph Toolbox deployed, see [Rook Ceph Docs - Ceph Toolbox](https://rook.io/docs/rook/v1.8/ceph-toolbox.html) for more information.
+This requires you to have the Rook Ceph Toolbox deployed, see [Ceph Toolbox](ceph-toolbox.md) for more information.
 
 ```console
 kubectl -n rook-ceph exec -it $(kubectl -n rook-ceph get pod -l "app=rook-ceph-tools" -o jsonpath='{.items[0].metadata.name}') -- bash
@@ -246,7 +246,7 @@ spec:
 
 Depending your hosts, you might not need to even have the `ceph` packages installed. If you are using Rook Ceph, you normally don't need any ceph related packages on the hosts.
 
-Should this have not fixed your issue, you might be running into some other permission issue. If your hosts are using a Linux distribution that uses SELinux, you might need to follow these steps to re-configure the Rook Ceph operator: [Rook Ceph Docs - OpenShift Special Configuration Guide](https://rook.io/docs/rook/v1.8/ceph-openshift.html#rook-settings).
+Should this have not fixed your issue, you might be running into some other permission issue. If your hosts are using a Linux distribution that uses SELinux, you might need to follow these steps to re-configure the Rook Ceph operator: [OpenShift Special Configuration Guide](../Getting-Started/ceph-openshift.md#rook-settings).
 
 ***
 

--- a/Documentation/Troubleshooting/node-maintenance.md
+++ b/Documentation/Troubleshooting/node-maintenance.md
@@ -36,4 +36,4 @@ Here are the steps for the same:
 
 ### **NOTE**
 
-For OSD Maintenance and management, please refer to [Ceph OSD Management](https://rook.io/docs/rook/latest/Storage-Configuration/Advanced/ceph-osd-mgmt/) from [rook.io](https://rook.io/) documentation.
+For OSD Maintenance and management, please refer to [Ceph OSD Management docs](../Storage-Configuration/Advanced/ceph-osd-mgmt.md).

--- a/Documentation/Troubleshooting/troubleshooting.md
+++ b/Documentation/Troubleshooting/troubleshooting.md
@@ -1,0 +1,35 @@
+---
+title: "Troubleshooting"
+---
+
+To help troubleshoot your Koor Storage Distribution clusters, here are some tips on what information will help solve the issues you might be seeing.
+If after trying the suggestions found on this page and the problem is not resolved, the Koor Storage Distribution team is very happy to help you troubleshoot the issues through [GitHub Discussions](https://github.com/koor-tech/koor/discussions).
+
+## Troubleshooting Techniques
+
+Kubernetes status and logs are the main resources needed to investigate issues in any Rook cluster.
+
+## Kubernetes Tools
+
+Kubernetes status is the first line of investigating when something goes wrong with the cluster. Here are a few artifacts that are helpful to gather:
+
+* Rook pod status:
+  * `kubectl get pod -n <cluster-namespace> -o wide`
+    * e.g., `kubectl get pod -n rook-ceph -o wide`
+* Logs for Rook pods
+  * Logs for the operator: `kubectl logs -n <cluster-namespace> -l app=<storage-backend-operator>`
+    * e.g., `kubectl logs -n rook-ceph -l app=rook-ceph-operator`
+  * Logs for a specific pod: `kubectl logs -n <cluster-namespace> <pod-name>`, or a pod using a label such as mon1: `kubectl logs -n <cluster-namespace> -l <label-matcher>`
+    * e.g., `kubectl logs -n rook-ceph -l mon=a`
+  * Logs on a specific node to find why a PVC is failing to mount:
+    * Connect to the node, then get kubelet logs (if your distro is using systemd): `journalctl -u kubelet`
+  * Pods with multiple containers
+    * For all containers, in order: `kubectl -n <cluster-namespace> logs <pod-name> --all-containers`
+    * For a single container: `kubectl -n <cluster-namespace> logs <pod-name> -c <container-name>`
+  * Logs for pods which are no longer running: `kubectl -n <cluster-namespace> logs --previous <pod-name>`
+
+Some pods have specialized init containers, so you may need to look at logs for different containers
+within the pod.
+
+* `kubectl -n <namespace> logs <pod-name> -c <container-name>`
+* Other Rook artifacts: `kubectl -n <cluster-namespace> get all`

--- a/Documentation/Troubleshooting/troubleshooting.md
+++ b/Documentation/Troubleshooting/troubleshooting.md
@@ -13,23 +13,85 @@ Kubernetes status and logs are the main resources needed to investigate issues i
 
 Kubernetes status is the first line of investigating when something goes wrong with the cluster. Here are a few artifacts that are helpful to gather:
 
-* Rook pod status:
-  * `kubectl get pod -n <cluster-namespace> -o wide`
-    * e.g., `kubectl get pod -n rook-ceph -o wide`
-* Logs for Rook pods
-  * Logs for the operator: `kubectl logs -n <cluster-namespace> -l app=<storage-backend-operator>`
-    * e.g., `kubectl logs -n rook-ceph -l app=rook-ceph-operator`
-  * Logs for a specific pod: `kubectl logs -n <cluster-namespace> <pod-name>`, or a pod using a label such as mon1: `kubectl logs -n <cluster-namespace> -l <label-matcher>`
-    * e.g., `kubectl logs -n rook-ceph -l mon=a`
-  * Logs on a specific node to find why a PVC is failing to mount:
-    * Connect to the node, then get kubelet logs (if your distro is using systemd): `journalctl -u kubelet`
-  * Pods with multiple containers
-    * For all containers, in order: `kubectl -n <cluster-namespace> logs <pod-name> --all-containers`
-    * For a single container: `kubectl -n <cluster-namespace> logs <pod-name> -c <container-name>`
-  * Logs for pods which are no longer running: `kubectl -n <cluster-namespace> logs --previous <pod-name>`
+### Rook Pod Status
+
+```console
+kubectl get -n <cluster-namespace> pod -o wide
+kubectl get -n rook-ceph pod -o wide
+```
+
+### Logs for Rook Pods
+
+Logs for the operator Pod:
+
+```console
+kubectl logs -n <cluster-namespace> -l app=<storage-backend-operator>
+kubectl logs -n rook-ceph -l app=rook-ceph-operator
+```
+
+Logs for a specific pod:
+
+```console
+kubectl logs -n <cluster-namespace> <pod-name>
+```
+
+Logs of a pod selected using labels, such as `mon=a`:
+
+```console
+kubectl logs -n <cluster-namespace> -l <label-matcher>
+kubectl logs -n rook-ceph -l mon=a
+```
 
 Some pods have specialized init containers, so you may need to look at logs for different containers
-within the pod.
+within the pod. To get the logs for a specific container of a pod:
 
-* `kubectl -n <namespace> logs <pod-name> -c <container-name>`
-* Other Rook artifacts: `kubectl -n <cluster-namespace> get all`
+```console
+kubectl logs -n <namespace> <pod-name> -c <container-name>
+kubectl logs -n rook-ceph rook-ceph-mon-b-55549bc497-phgtz -c chown-container-data-dir
+```
+
+#### Pods with multiple containers
+
+For all container logs:
+
+```console
+kubectl logs -n <cluster-namespace> <pod-name> --all-containers
+kubectl logs -n rook-ceph rook-ceph-mon-b-55549bc497-phgtz --all-containers
+```
+
+For a single container:
+
+```console
+kubectl logs -n <cluster-namespace> <pod-name> -c <container-name>
+kubectl logs -n rook-ceph rook-ceph-mon-b-55549bc497-phgtz -c mon
+```
+
+Logs for pods which are no longer running:
+
+```console
+kubectl logs -n <cluster-namespace> <pod-name> --previous
+kubectl logs -n rook-ceph rook-ceph-mon-b-55549bc497-phgtz --previous
+```
+
+### Logs from a specific Node/ Server
+
+To find why a PVC is failing to mount:
+
+1. Check the Pod Events (at the bottom of the command's output)
+
+    ```console
+    kubectl describe pod <pod-name>
+    ```
+
+2. Verify that the Node is shown as `Ready` in your cluster using:
+
+    ```console
+    kubectl get nodes
+    ```
+
+3. Connect to the node (e.g., use `ssh`)
+4. Get the kubelet service logs (if your distro is using systemd)
+
+    ```console
+    journalctl -u kubelet
+    ```

--- a/Documentation/stylesheets/extra.css
+++ b/Documentation/stylesheets/extra.css
@@ -6,3 +6,7 @@
 .md-header {
   background-color: #1d2628;
 }
+
+[data-md-color-primary="koor"] {
+  --md-primary-fg-color: #19dda5;
+}

--- a/Documentation/stylesheets/extra.css
+++ b/Documentation/stylesheets/extra.css
@@ -10,3 +10,7 @@
 [data-md-color-primary="koor"] {
   --md-primary-fg-color: #19dda5;
 }
+
+[data-md-color-primary="koor-dark"] {
+  --md-primary-fg-color: #119671;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,18 @@ theme:
   favicon: https://koor.tech/images/favicon.svg
   logo: https://koor.tech/images/logo.svg
   palette:
-    scheme: "default"
+    - scheme: "default"
+      primary: "koor"
+      accent: "deep orange"
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - scheme: "slate"
+      primary: "koor"
+      accent: "red"
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
   icon:
     repo: fontawesome/brands/github
   features:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,15 +21,17 @@ theme:
   favicon: https://koor.tech/images/favicon.svg
   logo: https://koor.tech/images/logo.svg
   palette:
-    - scheme: "default"
+    - media: "(prefers-color-scheme: light)"
+      scheme: "default"
       primary: "koor"
       accent: "deep orange"
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
-    - scheme: "slate"
-      primary: "koor"
-      accent: "red"
+    - media: "(prefers-color-scheme: dark)"
+      scheme: "slate"
+      primary: "koor-dark"
+      accent: "deep orange"
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode


### PR DESCRIPTION
**Description of your changes:**

Not all of them might applicable anymore for the latest versions of Rook/Ceph.
This also adds a toggle to enable a dark/light mode on the docs.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

Skipping CI due to only docs and docs config changes which are covered by the still running CI checks.

**Which issue is resolved by this Pull Request:**
Resolves KSD-103

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://docs.koor.tech/docs/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://docs.koor.tech/docs/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/koor-tech/koor/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
