### PR TITLE
docs: change colors for dark mode

### DIFF
--- a/Documentation/stylesheets/extra.css
+++ b/Documentation/stylesheets/extra.css
@@ -10,3 +10,7 @@
 [data-md-color-primary="koor"] {
   --md-primary-fg-color: #19dda5;
 }
+
+[data-md-color-primary="koor-dark"] {
+  --md-primary-fg-color: #119671;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,15 +21,17 @@ theme:
   favicon: https://koor.tech/images/favicon.svg
   logo: https://koor.tech/images/logo.svg
   palette:
-    - scheme: "default"
+    - media: "(prefers-color-scheme: light)"
+      scheme: "default"
       primary: "koor"
       accent: "deep orange"
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
-    - scheme: "slate"
-      primary: "koor"
-      accent: "red"
+    - media: "(prefers-color-scheme: dark)"
+      scheme: "slate"
+      primary: "koor-dark"
+      accent: "deep orange"
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode


### PR DESCRIPTION
Light mode stays the same

![Screenshot from 2023-01-05 09-24-27](https://user-images.githubusercontent.com/3438324/210808709-482a316d-f4a2-46c1-bd3f-25dba049c2c7.png)

Dark mode has the dark green
![Screenshot from 2023-01-05 09-23-56](https://user-images.githubusercontent.com/3438324/210808733-189f12fa-7241-4d03-a9f1-c3bb90dff265.png)

