### PR TITLE
chore: restore readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,27 @@
-<img alt="Rook" src="Documentation/media/logo.svg" width="50%" height="50%">
+# Koor Storage Distribution
 
-[![CNCF Status](https://img.shields.io/badge/cncf%20status-graduated-blue.svg)](https://www.cncf.io/projects)
-[![GitHub release](https://img.shields.io/github/release/rook/rook/all.svg)](https://github.com/rook/rook/releases)
-[![Docker Pulls](https://img.shields.io/docker/pulls/rook/ceph)](https://hub.docker.com/u/rook)
-[![Go Report Card](https://goreportcard.com/badge/github.com/rook/rook)](https://goreportcard.com/report/github.com/rook/rook)
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1599/badge)](https://bestpractices.coreinfrastructure.org/projects/1599)
-[![Security scanning](https://github.com/rook/rook/actions/workflows/synk.yaml/badge.svg)](https://github.com/rook/rook/actions/workflows/synk.yaml)
-[![Slack](https://slack.rook.io/badge.svg)](https://slack.rook.io)
-[![Twitter Follow](https://img.shields.io/twitter/follow/rook_io.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=rook_io&user_id=788180534543339520)
+[![GitHub release](https://img.shields.io/github/release/koor-tech/koor/all.svg)](https://github.com/koor-tech/koor/releases)
+[![Docker Pulls](https://img.shields.io/docker/pulls/koor-tech/ceph)](https://hub.docker.com/u/koorinc)
+[![Go Report Card](https://goreportcard.com/badge/github.com/koor-tech/koor)](https://goreportcard.com/report/github.com/koor-tech/koor)
+[![Security scanning](https://github.com/koor-tech/koor/actions/workflows/synk.yaml/badge.svg)](https://github.com/koor-tech/koor/actions/workflows/synk.yaml)
+[![Twitter Follow](https://img.shields.io/twitter/follow/koor_tech.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=koor_tech&user_id=1509666502714265604)
 
-# What is Rook?
+## What is Koor Storage Distribution?
 
-Rook is an open source **cloud-native storage orchestrator** for Kubernetes, providing the platform, framework, and support for Ceph storage to natively integrate with Kubernetes.
+The Koor Storage Distribution is an open source **cloud-native storage orchestrator** for Kubernetes, providing the platform, framework, and support for Ceph storage to natively integrate with Kubernetes. It is forked from the [Rook open source project](https://github.com/rook/rook).
 
 [Ceph](https://ceph.com/) is a distributed storage system that provides file, block and object storage and is deployed in large scale production clusters.
 
-Rook automates deployment and management of Ceph to provide self-managing, self-scaling, and self-healing storage services.
-The Rook operator does this by building on Kubernetes resources to deploy, configure, provision, scale, upgrade, and monitor Ceph.
+Koor Storage Distribution automates deployment and management of Ceph to provide self-managing, self-scaling, and self-healing storage services.
+The Koor Storage Distribution operator does this by building on Kubernetes resources to deploy, configure, provision, scale, upgrade, and monitor Ceph.
 
 The status of the Ceph storage provider is **Stable**. Features and improvements will be planned for many future versions. Upgrades between versions are provided to ensure backward compatibility between releases.
 
-Rook is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CNCF) as a [graduated](https://www.cncf.io/announcements/2020/10/07/cloud-native-computing-foundation-announces-rook-graduation/) level project. If you are a company that wants to help shape the evolution of technologies that are container-packaged, dynamically-scheduled and microservices-oriented, consider joining the CNCF. For details about who's involved and how Rook plays a role, read the CNCF [announcement](https://www.cncf.io/blog/2018/01/29/cncf-host-rook-project-cloud-native-storage-capabilities).
+The Rook project is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CNCF) as a [graduated](https://www.cncf.io/announcements/2020/10/07/cloud-native-computing-foundation-announces-rook-graduation/) level project. If you are a company that wants to help shape the evolution of technologies that are container-packaged, dynamically-scheduled and microservices-oriented, consider joining the CNCF. For details about who's involved and how Rook plays a role, read the CNCF [announcement](https://www.cncf.io/blog/2018/01/29/cncf-host-rook-project-cloud-native-storage-capabilities).
 
 ## Getting Started and Documentation
 
-For installation, deployment, and administration, see our [Documentation](https://rook.github.io/docs/rook/latest-release) and [QuickStart Guide](https://rook.github.io/docs/rook/latest-release/Getting-Started/quickstart).
+For installation, deployment, and administration, see our [Documentation](https://docs.koor.tech/latest-release) and [QuickStart Guide](https://docs.koor.tech/latest-release/Getting-Started/quickstart).
 
 ## Contributing
 
@@ -32,12 +29,12 @@ We welcome contributions. See [Contributing](CONTRIBUTING.md) to get started.
 
 ## Report a Bug
 
-For filing bugs, suggesting improvements, or requesting new features, please open an [issue](https://github.com/rook/rook/issues).
+For filing bugs, suggesting improvements, or requesting new features, please open an [issue](https://github.com/koor-tech/koor/issues).
 
 ### Reporting Security Vulnerabilities
 
-If you find a vulnerability or a potential vulnerability in Rook please let us know immediately at
-[cncf-rook-security@lists.cncf.io](mailto:cncf-rook-security@lists.cncf.io). We'll send a confirmation email to acknowledge your
+If you find a vulnerability or a potential vulnerability in Koor Storage Distribution please let us know immediately at
+[security@koor.tech](mailto:security@koor.tech). We'll send a confirmation email to acknowledge your
 report, and we'll send an additional email when we've identified the issues positively or
 negatively.
 
@@ -47,20 +44,16 @@ For further details, please see the complete [security release process](SECURITY
 
 Please use the following to reach members of the community:
 
-- Slack: Join our [slack channel](https://slack.rook.io)
-- GitHub: Start a [discussion](https://github.com/rook/rook/discussions) or open an [issue](https://github.com/rook/rook/issues)
-- Twitter: [@rook_io](https://twitter.com/rook_io)
-- Security topics: [cncf-rook-security@lists.cncf.io](#reporting-security-vulnerabilities)
+- GitHub: Start a [discussion](https://github.com/koor-tech/koor/discussions) or open an [issue](https://github.com/koor-tech/koor/issues)
+- Twitter: [@koor_tech](https://twitter.com/koor_tech)
+- Security topics: [security@koor.tech](#reporting-security-vulnerabilities)
+- Office hours meeting: We have a bi-weekly office hour meeting to answer questions and help with any issues around Koor, Rook and Ceph, see [office hours section](#office-hours).
 
-## Community Meeting
+## Office Hours
 
-A regular community meeting takes place every other [Wednesday at 10:30 AM PT (Pacific Time)](https://meet.google.com/ido-bbdm-pqc).
-Convert to your [local timezone](http://www.thetimezoneconverter.com/?t=9:00&tz=PT%20%28Pacific%20Time%29).
+A regular office hour meeting takes place every other [Wednesday at 10:30 AM PT (Pacific Time)](https://meet.google.com/ido-bbdm-pqc) to answer any questions and help with issues around Koor Storage Distribution, Rook and Ceph. Convert to your [local timezone](http://www.thetimezoneconverter.com/?t=10:30&tz=PT%20%28Pacific%20Time%29).
 
-Any changes to the meeting schedule will be added to the [agenda doc](https://docs.google.com/document/d/1twakYk3XNZD_1Xmi3GDXojuPPkUp7fb06e_4rtgNWdM/edit?usp=sharing) and posted to [Slack #announcements](https://rook-io.slack.com/messages/C76LLCEE7/).
-
-Anyone who wants to discuss the direction of the project, design and implementation reviews, or general questions with the broader community is welcome and encouraged to join.
-
+- You can add the meeting to your calendar using [this link (invite is sent through Google Calendar)](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NHRhMTBqY2Y0ZTFkb2x1MnZkYThma290M2FfMjAyMjExMDlUMTgzMDAwWiBjXzJjY2Y0OWY1NDZlYzRlYzQ0NzhhMmRiMDI1ZmVjYjdmN2U4MDgxMjZkYmViNzY3MWYxMzg1NGVlNjgwNmQyMmRAZw&tmsrc=c_2ccf49f546ec4ec4478a2db025fecb7f7e808126dbeb7671f13854ee6806d22d%40group.calendar.google.com&scp=ALL).
 - Meeting link: <https://meet.google.com/ido-bbdm-pqc>
 - [Current agenda and past meeting notes](https://docs.google.com/document/d/1twakYk3XNZD_1Xmi3GDXojuPPkUp7fb06e_4rtgNWdM/edit?usp=sharing)
 - [Past meeting recordings](https://www.youtube.com/@koor-tech)
@@ -68,12 +61,13 @@ Anyone who wants to discuss the direction of the project, design and implementat
 
 ## Official Releases
 
-Official releases of Rook can be found on the [releases page](https://github.com/rook/rook/releases).
-Please note that it is **strongly recommended** that you use [official releases](https://github.com/rook/rook/releases) of Rook, as unreleased versions from the master branch are subject to changes and incompatibilities that will not be supported in the official releases.
+Official releases of Koor Storage Distribution can be found on the [releases page](https://github.com/koor-tech/koor/releases).
+Please note that it is **strongly recommended** that you use [official releases](https://github.com/koor-tech/koor/releases) of Koor Storage Distribution, as unreleased versions from the master branch are subject to changes and incompatibilities that will not be supported in the official releases.
 Builds from the master branch can have functionality changed and even removed at any time without compatibility support and without prior notice.
 
 ## Licensing
 
 Rook is under the Apache 2.0 license.
+Koor Storage Distribution proprietary code is in folder "ee/" or marked by an appropriate license header.
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Frook%2Frook.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Frook%2Frook?ref=badge_large)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,8 @@ plugins:
   - exclude:
       glob:
         - README.md
+        - "*.gotmpl"
+        - "*.gotmpl.md"
   - awesome-pages
   - macros:
       module_name: .docs/macros/includes/main


### PR DESCRIPTION
**Description of your changes:**

Restores README.md to how it was before the forcepush™, [see here](https://github.com/koor-tech/koor/tree/2c469cb021093af432300b90c11c2f48efd2d66c). I added a few changes too, so please make sure they are ok.

**Why?**

Many blog posts refer to [the office hours link](https://github.com/koor-tech/koor#office-hours) in the readme file, but that like is broken without this change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
