### PR TITLE
helm: add extended-ceph-exporter chart as a dependency

### DIFF
--- a/Documentation/Helm-Charts/ceph-cluster-chart.md
+++ b/Documentation/Helm-Charts/ceph-cluster-chart.md
@@ -66,6 +66,11 @@ The following table lists the configurable parameters of the rook-operator chart
 | `cephObjectStores` | A list of CephObjectStore configurations to deploy | See [below](#ceph-object-stores) |
 | `clusterName` | The metadata.name of the CephCluster CR | The same as the namespace |
 | `configOverride` | Cluster ceph.conf override | `nil` |
+| `extendedCephExporter.enabled` | If enabled the extended-ceph-exporter will be installed | `false` |
+| `extendedCephExporter.serviceMonitor` | Enable Prometheus ServiceMonitor creation, requires the prometheus-operator to be installed. | `{"additionalLabels":{},"enabled":false,"namespaceSelector":null,"scrapeInterval":"30s"}` |
+| `extendedCephExporter.serviceMonitor.additionalLabels` | Additional Labels for the ServiceMonitor object | `{}` |
+| `extendedCephExporter.serviceMonitor.enabled` | Specifies whether a prometheus-operator ServiceMonitor should be created | `false` |
+| `extendedCephExporter.serviceMonitor.scrapeInterval` | Interval at which metrics should be scraped | `"30s"` |
 | `ingress.dashboard` | Enable an ingress for the ceph-dashboard | `{}` |
 | `kubeVersion` | Optional override of the target kubernetes version | `nil` |
 | `monitoring.createPrometheusRules` | Whether to create the Prometheus rules for Ceph alerts | `false` |

--- a/build/makelib/helm.mk
+++ b/build/makelib/helm.mk
@@ -39,7 +39,9 @@ define helm.chart
 $(HELM_OUTPUT_DIR)/$(1)-$(VERSION).tgz: $(HELM) $(HELM_OUTPUT_DIR) $(shell find $(HELM_CHARTS_DIR)/$(1) -type f)
 	@echo === helm package $(1)
 	@rm -rf $(OUTPUT_DIR)/$(1)
+	@cd $(HELM_CHARTS_DIR)/$(1) && $(HELM) dependency update
 	@cp -aL $(HELM_CHARTS_DIR)/$(1) $(OUTPUT_DIR)
+	@cp -aL $(HELM_CHARTS_DIR)/library $(OUTPUT_DIR)
 	@$(SED_IN_PLACE) 's|VERSION|$(VERSION)|g' $(OUTPUT_DIR)/$(1)/values.yaml
 	@$(HELM) lint $(abspath $(OUTPUT_DIR)/$(1)) --set image.tag=$(VERSION)
 	@$(HELM) package --version $(VERSION) --app-version $(VERSION) -d $(HELM_OUTPUT_DIR) $(abspath $(OUTPUT_DIR)/$(1))

--- a/deploy/charts/.gitignore
+++ b/deploy/charts/.gitignore
@@ -1,0 +1,3 @@
+# Helm
+Chart.lock
+*.tgz

--- a/deploy/charts/rook-ceph-cluster/Chart.yaml
+++ b/deploy/charts/rook-ceph-cluster/Chart.yaml
@@ -7,6 +7,10 @@ icon: https://rook.io/images/rook-logo.svg
 sources:
   - https://github.com/rook/rook
 dependencies:
-- name: library
-  version: "0.0.1"
-  repository: "file://../library"
+  - name: library
+    version: "0.0.1"
+    repository: "file://../library"
+  - name: extended-ceph-exporter
+    version: "1.2.5"
+    repository: "https://koor-tech.github.io/extended-ceph-exporter"
+    condition: extendedCephExporter.enabled

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -611,3 +611,24 @@ cephObjectStores:
       #     - objectstore.example.com
       #   secretName: ceph-objectstore-tls
       # ingressClassName: nginx
+
+extendedCephExporter:
+  # -- If enabled the extended-ceph-exporter will be installed
+  enabled: false
+
+  # -- Enable Prometheus ServiceMonitor creation, requires the prometheus-operator to be installed.
+  serviceMonitor:
+    # -- Specifies whether a prometheus-operator ServiceMonitor should be created
+    enabled: false
+    # -- Additional Labels for the ServiceMonitor object
+    additionalLabels: {}
+    #namespace: "monitoring"
+    namespaceSelector:
+    # Default: scrape .Release.Namespace only
+    # To scrape all, use the following:
+    #  matchNames:
+    #    - monitoring
+    #   any: true
+    # -- (duration) Interval at which metrics should be scraped
+    scrapeInterval: 30s
+    # honorLabels: true


### PR DESCRIPTION
**Description of your changes:**

Deploy the extended-ceph-exporter project alongside the rook-ceph-cluster chart to make RGW buckets and user monitoring easier.

**Which issue is resolved by this Pull Request:**
Resolves KSD-201

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.