### PR TITLE
ci: add action to backport_upstream everyday to a PR

### DIFF
--- a/.github/workflows/backport_upstream.yml
+++ b/.github/workflows/backport_upstream.yml
@@ -1,0 +1,54 @@
+name: Backport rook/rook upstream cronjob
+on:
+  # Triggers the workflow at 9:00 on Tuesday and Thursday.
+  schedule:
+    - cron: "0 9 * * 2,4"
+defaults:
+  run:
+    # reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+
+permissions:
+  contents: write
+  actions: write
+  pull-requests: write
+
+jobs:
+  push-commits-to-koor-repo:
+    name: Push commits to Koor Repository
+    runs-on: ubuntu-latest
+    if: github.repository == 'koor-tech/koor' && github.event_name == 'pull_request'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "Koor Bot"
+          git config --global user.email "info@koor.tech"
+
+      - name: pull rook upstream commits from latest master and create a PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          ee/scripts/merge_rook_master.sh
+          # if PR already exists, we simply push to it other open a PR
+          prs=$(gh pr list \
+          --repo "$GITHUB_REPOSITORY" \
+          --json baseRefName,headRefName \
+          --jq 'map(select(.baseRefName == "master" and .headRefName == "merge-rook-master")) | length')
+          if ((prs > 0)); then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          gh pr create --title 'Rebase Rook upstream to Koor' --body 'Created by Github action'
+
+      - name: consider debugging
+        if: failure()
+        timeout-minutes: 60
+        uses: ./.github/workflows/tmate_debug
+        with:
+          use-tmate: ${{ secrets.USE_TMATE }}

--- a/.github/workflows/backport_upstream.yml
+++ b/.github/workflows/backport_upstream.yml
@@ -17,7 +17,7 @@ jobs:
   push-commits-to-koor-repo:
     name: Push commits to Koor Repository
     runs-on: ubuntu-latest
-    if: github.repository == 'koor-tech/koor' && github.event_name == 'pull_request'
+    if: github.repository == 'koor-tech/koor'
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -40,11 +40,9 @@ jobs:
           --repo "$GITHUB_REPOSITORY" \
           --json baseRefName,headRefName \
           --jq 'map(select(.baseRefName == "master" and .headRefName == "merge-rook-master")) | length')
-          if ((prs > 0)); then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          if ((prs == 0)); then
+            gh pr create --title 'Merge Rook upstream to Koor' --body 'Created by Github action Backport rook/rook upstream cronjob'
           fi
-          gh pr create --title 'Merge Rook upstream to Koor' --body 'Created by Github action Backport rook/rook upstream cronjob'
 
       - name: consider debugging
         if: failure()

--- a/.github/workflows/backport_upstream.yml
+++ b/.github/workflows/backport_upstream.yml
@@ -44,7 +44,7 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          gh pr create --title 'Rebase Rook upstream to Koor' --body 'Created by Github action'
+          gh pr create --title 'Merge Rook upstream to Koor' --body 'Created by Github action Backport rook/rook upstream cronjob'
 
       - name: consider debugging
         if: failure()

--- a/ee/scripts/merge_rook_master.sh
+++ b/ee/scripts/merge_rook_master.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -x
+
+ROOK_BRANCH="master"
+
+if [[ -z "$GITHUB_TOKEN" ]]; then
+	echo "Set the GITHUB_TOKEN env variable."
+	exit 1
+fi
+
+git remote add rook_fork https://github.com/rook/rook.git
+git fetch rook_fork $ROOK_BRANCH
+
+set -o xtrace
+
+# do the merge
+git checkout -b merge-rook-master
+
+git merge rook_fork/$ROOK_BRANCH
+#specific files that will be completely ours
+git checkout --ours rook_fork/master -- README.md
+(git -c core.editor=/bin/true merge --continue) || (echo "Merge failed, try merging manual" && exit 1)
+
+# push back
+git push --force-with-lease origin merge-rook-master


### PR DESCRIPTION
**Description of your changes:**

Idea is to push rook upstream using cron to a PR everyday, if the PR
exists push new changes to the same PR otherwise create a new PR with
Rook upstream.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure)).
- [ ] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
