### PR TITLE
ci: use make target to install gen-crd-api-reference-docs

### DIFF
--- a/.github/workflows/backport_upstream.yml
+++ b/.github/workflows/backport_upstream.yml
@@ -23,6 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'koor-tech/koor'
     steps:
+      - name: Set up Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19
+
       - name: checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -50,10 +50,9 @@ jobs:
           make validate-and-gen-docs-crds
           DIFF_ON_DOCS=$(git diff --ignore-matching-lines='on git commit')
           if [ ! -z "$DIFF_ON_DOCS" ]; then
-          echo "Please run 'make generate-docs-crds' locally, commit the updated crds docs, and push the change"
+            echo "Please run 'make generate-docs-crds' locally, commit the updated crds docs, and push the change"
           fi
           git diff --ignore-matching-lines='on git commit' --exit-code
 
       - name: Build documentation using mkdocs
         run: make docs-build
-

--- a/Makefile
+++ b/Makefile
@@ -216,11 +216,11 @@ docs-preview: ## Preview the documentation through mkdocs
 docs-build:  ## Build the documentation to the `site/` directory
 	mkdocs build --strict
 
-generate-docs-crds: ## Build the documentation for CRD
-	@build/crds/generate-crd-docs.sh
+generate-docs-crds: $(GEN_CRD_API_REFERENCE_DOCS) ## Build the documentation for CRD
+	GEN_CRD_API_REFERENCE_DOCS="$(GEN_CRD_API_REFERENCE_DOCS)" build/crds/generate-crd-docs.sh
 
-validate-and-gen-docs-crds: ## Force generation of CRD documentation
-	build/crds/generate-crd-docs.sh --force
+validate-and-gen-docs-crds: $(GEN_CRD_API_REFERENCE_DOCS) ## Force generation of CRD documentation
+	GEN_CRD_API_REFERENCE_DOCS="$(GEN_CRD_API_REFERENCE_DOCS)" build/crds/generate-crd-docs.sh --force
 
 .PHONY: all build.common
 .PHONY: build build.all install test check vet fmt codegen mod.check clean distclean prune

--- a/build/crds/generate-crd-docs.sh
+++ b/build/crds/generate-crd-docs.sh
@@ -1,18 +1,13 @@
 #! /usr/bin/env bash
 
 SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
-GEN_CRD_API_REFERENCE_DOC_VERSION=v0.3.0
 SCRIPT_CHECK_DOCS_DIFF=$(git diff --name-only --diff-filter=M | grep -Ec '/types\.go$')
-
-install_generator() {
-    go install github.com/ahmetb/gen-crd-api-reference-docs@${GEN_CRD_API_REFERENCE_DOC_VERSION}
-}
+GEN_CRD_API_REFERENCE_DOCS="${GEN_CRD_API_REFERENCE_DOCS:-${SCRIPT_ROOT}/.cache/tools/$(go env GOHOSTARCH)/gen-crd-api-reference-docs}"
 
 run_gen() {
   if [[  "$SCRIPT_CHECK_DOCS_DIFF" -gt 0 || "$1" = "--force" ]]; then
     echo "differences found in types.go, rebuilding specification.md"
-    install_generator
-    gen-crd-api-reference-docs \
+    "${GEN_CRD_API_REFERENCE_DOCS}" \
         -config="${SCRIPT_ROOT}/crd-docs-config.json" \
         -template-dir="${SCRIPT_ROOT}/Documentation/gen-crd-api-reference-docs/template" \
         -api-dir="github.com/rook/rook/pkg/apis/ceph.rook.io" \

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -236,3 +236,22 @@ export CODE_GENERATOR=$(TOOLS_HOST_DIR)/code-generator-$(CODE_GENERATOR_VERSION)
 $(CODE_GENERATOR):
 	mkdir -p $(TOOLS_HOST_DIR)
 	curl -sL https://github.com/kubernetes/code-generator/archive/refs/tags/v${CODE_GENERATOR_VERSION}.tar.gz | tar -xz -C $(TOOLS_HOST_DIR)
+
+export GEN_CRD_API_REFERENCE_DOC_VERSION=v0.3.0
+GEN_CRD_API_REFERENCE_DOCS := $(TOOLS_HOST_DIR)/gen-crd-api-reference-docs
+
+$(GEN_CRD_API_REFERENCE_DOCS):
+	{ \
+		set -e ;\
+		mkdir -p $(TOOLS_HOST_DIR) ;\
+		GEN_CRD_API_REFERENCE_DOCS_TMP_DIR=$$(mktemp -d) ;\
+		cd $$GEN_CRD_API_REFERENCE_DOCS_TMP_DIR ;\
+		go mod init tmp;\
+		unset GOOS GOARCH ;\
+		export CGO_ENABLED=$(CGO_ENABLED_VALUE) ;\
+		export GOBIN=$$GEN_CRD_API_REFERENCE_DOCS_TMP_DIR ;\
+		echo === installing gen-crd-api-reference-docs ;\
+		go install github.com/ahmetb/gen-crd-api-reference-docs@$(GEN_CRD_API_REFERENCE_DOC_VERSION); \
+		mv $$GEN_CRD_API_REFERENCE_DOCS_TMP_DIR/gen-crd-api-reference-docs $(GEN_CRD_API_REFERENCE_DOCS) ;\
+		rm -rf $$GEN_CRD_API_REFERENCE_DOCS_TMP_DIR ;\
+	}


### PR DESCRIPTION
**Description of your changes:**

The CI has issues with the `go install` approach, it seems more reasonable to use a `make` target that downloads/ installs the tool to the `.cache/tools/` dir.

**Which issue is resolved by this Pull Request:**

https://github.com/koor-tech/koor/actions/runs/5265237151/jobs/9517603643

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
