### PR TITLE
design: add osd scrubbing schedule design doc

### DIFF
--- a/design/ceph/osd-scrubbing-schedule.md
+++ b/design/ceph/osd-scrubbing-schedule.md
@@ -1,0 +1,34 @@
+# OSD Scrubbing Schedule
+
+## Goal
+
+Adding a simple way to configure the Ceph OSD Scrubbing schedule options from the CephCluster CRD.
+
+## Current Solution
+
+Users need to update the `rook-config-override` and add the [Ceph OSD Scrubbing config options](https://docs.ceph.com/en/latest/rados/configuration/osd-config-ref/#scrubbing) as needed.
+
+## Proposed Solution
+
+Adding a new config structure to the CephCluster CRD under `.spec.storage` named `scrubbing:`.
+
+The config structure will contain the important parts for setting a schedule for the OSD scrubbing.
+
+```yaml
+spec:
+  # [...]
+  storage:
+    # [...]
+    scrubbingSchedule:
+      maxScrubsOps: 3
+      beginHour: 8
+      beginWeekDay: 1
+      endHour: 17
+      endWeekDay: 5
+      minScrubInterval: 1d
+      maxScrubInterval: 7d
+      deepScrubInterval: 7d
+  # [...]
+```
+
+This will use the Ceph config store to apply these settings to the cluster.


### PR DESCRIPTION
**Description of your changes:**

This adds a design document to control the OSD scrubbing schedule settings from the CephCluster CRD directly.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
