### PR TITLE
operator: add osd scrubbing schedule options

### DIFF
--- a/Documentation/CRDs/Cluster/ceph-cluster-crd.md
+++ b/Documentation/CRDs/Cluster/ceph-cluster-crd.md
@@ -77,6 +77,7 @@ For more details on the mons and when to choose a number other than `3`, see the
     * `useAllNodes`: `true` or `false`, indicating if all nodes in the cluster should be used for storage according to the cluster level storage selection and configuration values.
   If individual nodes are specified under the `nodes` field, then `useAllNodes` must be set to `false`.
     * `nodes`: Names of individual nodes in the cluster that should have their storage included in accordance with either the cluster level configuration specified above or any node specific overrides described in the next section below.
+    * `scrubbing`: OSD Scrubbing schedule configuration, see [OSD Scrubbing schedule](#osd-scrubbing-schedule).
   `useAllNodes` must be set to `false` to use specific nodes and their config.
   See [node settings](#node-settings) below.
     * `config`: Config settings applied to all OSDs on the node unless overridden by `devices`. See the [config settings](#osd-configuration-settings) below.
@@ -418,6 +419,23 @@ The following storage selection settings are specific to Ceph and do not apply t
 * `osdsPerDevice`**: The number of OSDs to create on each device. High performance devices such as NVMe can handle running multiple OSDs. If desired, this can be overridden for each node and each device.
 * `encryptedDevice`**: Encrypt OSD volumes using dmcrypt ("true" or "false"). By default this option is disabled. See [encryption](http://docs.ceph.com/docs/master/ceph-volume/lvm/encryption/) for more information on encryption in Ceph.
 * `crushRoot`: The value of the `root` CRUSH map label. The default is `default`. Generally, you should not need to change this. However, if any of your topology labels may have the value `default`, you need to change `crushRoot` to avoid conflicts, since CRUSH map values need to be unique.
+
+### OSD Scrubbing Schedule
+
+These options can be used to set a custom OSD scrubbing schedule easily instead of having to use the Ceph config override:
+
+* `applySchedule`: Whether the scrubbing schedule specified should be applied to the cluster.
+* `maxScrubOps`: Max scrubbing operations happening at the same time. Default: `3`.
+* `beginHour`: Begin hour of scrubbing schedule. Default `0`. Setting both `BeginHour` and `EndHour` to `0`, will allow scrubbing the entire day.
+* `endHour`: End hour of scrubbing schedule. Default `0`.
+* `beginWeekDay`: Begin week day of scrubbing schedule. `0` = Sunday, `1` = Monday, etc. Default: `0`.
+* `endWeekDay`: End week day of scrubbing schedule. `0` = Sunday, `1` = Monday, etc. Default: `0`.
+* `minScrubInterval`: Minimum interval to wait before scrubbing again. Default: `24h` (1 day).
+* `maxScrubInterval`: Maximum interval to wait before scrubbing is forced. Default: `168h` (7 days).
+* `deepScrubInterval`: Interval at which to do deeb scrubbing instead of a "light" scrubbing. Default: `168h` (7 days).
+* `scrubSleepSeconds`: Set the scrub sleep as a duration. Default: `0ms`, if you are impacted by scrubbing causing performance issues, it is recommended to set it to at least `100ms`.
+
+For more information about Ceph OSD scrubbing checkout [OSD Config Reference - Scrubbing - Ceph Documentation](https://docs.ceph.com/en/latest/rados/configuration/osd-config-ref/#scrubbing).
 
 ### Annotations and Labels
 

--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -10170,6 +10170,170 @@ int32
 </td>
 </tr></tbody>
 </table>
+<h3 id="ceph.rook.io/v1.Scrubbing">Scrubbing
+</h3>
+<p>
+(<em>Appears on:</em><a href="#ceph.rook.io/v1.StorageScopeSpec">StorageScopeSpec</a>)
+</p>
+<div>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>applySchedule</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ApplySchedule whether the scrubbing schedule specified should be applied to the cluster</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxScrubOps</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Max scrubbing operations at the same time</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>beginHour</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Begin hour of scrubbing schedule
+Setting both <code>BeginHour</code> and <code>EndHour</code> to <code>0</code>, will allow scrubbing the entire day.
+Default: <code>0</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>endHour</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>End hour of scrubbing schedule
+Default: <code>0</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>beginWeekDay</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Begin week day of scrubbing schedule
+<code>0</code> = Sunday, <code>1</code> = Monday, etc.
+Default: <code>0</code> = Sunday</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>endWeekDay</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>End week day of scrubbing schedule
+<code>0</code> = Sunday, <code>1</code> = Monday, etc.
+Default: <code>0</code> = Sunday</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minScrubInterval</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Minimum interval to wait before scrubbing again
+Default: <code>24h</code> (1 day)
+Note: due to discrepancies in validation vs parsing, we use a Pattern instead of <code>Format=duration</code>. Thanks to
+<a href="https://github.com/openshift/hive/pull/1684">https://github.com/openshift/hive/pull/1684</a> for showing a way to fix it.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>maxScrubInterval</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Maximum interval to wait before scrubbing is forced
+Default: <code>168h</code> (7 days)
+Note: due to discrepancies in validation vs parsing, we use a Pattern instead of <code>Format=duration</code>. Thanks to
+<a href="https://github.com/openshift/hive/pull/1684">https://github.com/openshift/hive/pull/1684</a> for showing a way to fix it.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deepScrubInterval</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Interval at which to do deeb scrubbing instead of a &ldquo;light&rdquo; scrubbing
+Default: <code>168h</code> (7 days)
+Note: due to discrepancies in validation vs parsing, we use a Pattern instead of <code>Format=duration</code>. Thanks to
+<a href="https://github.com/openshift/hive/pull/1684">https://github.com/openshift/hive/pull/1684</a> for showing a way to fix it.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scrubSleepSeconds</code><br/>
+<em>
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Set the scrub sleep as a duration
+Default <code>0ms</code>, recommended if you are impacted by scrubbing <code>100ms</code>
+Note: due to discrepancies in validation vs parsing, we use a Pattern instead of <code>Format=duration</code>. Thanks to
+<a href="https://github.com/openshift/hive/pull/1684">https://github.com/openshift/hive/pull/1684</a> for showing a way to fix it.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="ceph.rook.io/v1.SecuritySpec">SecuritySpec
 </h3>
 <p>
@@ -10977,6 +11141,19 @@ Selection
 <em>
 <a href="#ceph.rook.io/v1.StorageClassDeviceSet">
 []StorageClassDeviceSet
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>scrubbing</code><br/>
+<em>
+<a href="#ceph.rook.io/v1.Scrubbing">
+Scrubbing
 </a>
 </em>
 </td>

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -2970,6 +2970,59 @@ spec:
                       type: array
                     onlyApplyOSDPlacement:
                       type: boolean
+                    scrubbing:
+                      nullable: true
+                      properties:
+                        applySchedule:
+                          description: ApplySchedule whether the scrubbing schedule specified should be applied to the cluster
+                          type: boolean
+                        beginHour:
+                          default: 0
+                          description: 'Begin hour of scrubbing schedule Setting both `BeginHour` and `EndHour` to `0`, will allow scrubbing the entire day. Default: `0`'
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        beginWeekDay:
+                          default: 0
+                          description: 'Begin week day of scrubbing schedule `0` = Sunday, `1` = Monday, etc. Default: `0` = Sunday'
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        deepScrubInterval:
+                          description: 'Interval at which to do deeb scrubbing instead of a "light" scrubbing Default: `168h` (7 days) Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to https://github.com/openshift/hive/pull/1684 for showing a way to fix it.'
+                          pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                          type: string
+                        endHour:
+                          default: 0
+                          description: 'End hour of scrubbing schedule Default: `0`'
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        endWeekDay:
+                          default: 0
+                          description: 'End week day of scrubbing schedule `0` = Sunday, `1` = Monday, etc. Default: `0` = Sunday'
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        maxScrubInterval:
+                          description: 'Maximum interval to wait before scrubbing is forced Default: `168h` (7 days) Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to https://github.com/openshift/hive/pull/1684 for showing a way to fix it.'
+                          pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                          type: string
+                        maxScrubOps:
+                          default: 3
+                          description: Max scrubbing operations at the same time
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        minScrubInterval:
+                          description: 'Minimum interval to wait before scrubbing again Default: `24h` (1 day) Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to https://github.com/openshift/hive/pull/1684 for showing a way to fix it.'
+                          pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                          type: string
+                        scrubSleepSeconds:
+                          description: 'Set the scrub sleep as a duration Default `0ms`, recommended if you are impacted by scrubbing `100ms` Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to https://github.com/openshift/hive/pull/1684 for showing a way to fix it.'
+                          pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                          type: string
+                      type: object
                     storageClassDeviceSets:
                       items:
                         description: StorageClassDeviceSet is a storage class device set

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -268,6 +268,19 @@ spec:
     #     deviceFilter: "^sd."
     # when onlyApplyOSDPlacement is false, will merge both placement.All() and placement.osd
     onlyApplyOSDPlacement: false
+    # OSD scrubbing schedule config, see Ceph Cluster CRD documentation section `OSD Scrubbing Schedule`
+    scrubbing:
+      # Whether the scrubbing schedule specified should be applied to the cluster
+      applySchedule: false
+      maxScrubOps: 3
+      beginHour: 0
+      endHour: 0
+      beginWeekDay: 1
+      endWeekDay: 0
+      minScrubInterval: 24h
+      maxScrubInterval: 168h
+      deepScrubInterval: 168h
+      scrubSleepSeconds: 100ms
   # The section for configuring management of daemon disruptions during upgrade or fencing.
   disruptionManagement:
     # If true, the operator will create and manage PodDisruptionBudgets for OSD, Mon, RGW, and MDS daemons. OSD PDBs are managed dynamically

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -2968,6 +2968,59 @@ spec:
                       type: array
                     onlyApplyOSDPlacement:
                       type: boolean
+                    scrubbing:
+                      nullable: true
+                      properties:
+                        applySchedule:
+                          description: ApplySchedule whether the scrubbing schedule specified should be applied to the cluster
+                          type: boolean
+                        beginHour:
+                          default: 0
+                          description: 'Begin hour of scrubbing schedule Setting both `BeginHour` and `EndHour` to `0`, will allow scrubbing the entire day. Default: `0`'
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        beginWeekDay:
+                          default: 0
+                          description: 'Begin week day of scrubbing schedule `0` = Sunday, `1` = Monday, etc. Default: `0` = Sunday'
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        deepScrubInterval:
+                          description: 'Interval at which to do deeb scrubbing instead of a "light" scrubbing Default: `168h` (7 days) Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to https://github.com/openshift/hive/pull/1684 for showing a way to fix it.'
+                          pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                          type: string
+                        endHour:
+                          default: 0
+                          description: 'End hour of scrubbing schedule Default: `0`'
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        endWeekDay:
+                          default: 0
+                          description: 'End week day of scrubbing schedule `0` = Sunday, `1` = Monday, etc. Default: `0` = Sunday'
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        maxScrubInterval:
+                          description: 'Maximum interval to wait before scrubbing is forced Default: `168h` (7 days) Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to https://github.com/openshift/hive/pull/1684 for showing a way to fix it.'
+                          pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                          type: string
+                        maxScrubOps:
+                          default: 3
+                          description: Max scrubbing operations at the same time
+                          format: int64
+                          minimum: 1
+                          type: integer
+                        minScrubInterval:
+                          description: 'Minimum interval to wait before scrubbing again Default: `24h` (1 day) Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to https://github.com/openshift/hive/pull/1684 for showing a way to fix it.'
+                          pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                          type: string
+                        scrubSleepSeconds:
+                          description: 'Set the scrub sleep as a duration Default `0ms`, recommended if you are impacted by scrubbing `100ms` Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to https://github.com/openshift/hive/pull/1684 for showing a way to fix it.'
+                          pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                          type: string
+                      type: object
                     storageClassDeviceSets:
                       items:
                         description: StorageClassDeviceSet is a storage class device set

--- a/design/ceph/osd-scrubbing-schedule.md
+++ b/design/ceph/osd-scrubbing-schedule.md
@@ -19,15 +19,17 @@ spec:
   # [...]
   storage:
     # [...]
-    scrubbingSchedule:
-      maxScrubsOps: 3
+    scrubbing:
+      applySchedule: true
+      maxScrubOps: 3
       beginHour: 8
-      beginWeekDay: 1
       endHour: 17
+      beginWeekDay: 1
       endWeekDay: 5
-      minScrubInterval: 1d
-      maxScrubInterval: 7d
-      deepScrubInterval: 7d
+      minScrubInterval: 24h
+      maxScrubInterval: 168h
+      deepScrubInterval: 168h
+      scrubSleepSeconds: 100ms
   # [...]
 ```
 

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -2604,6 +2604,9 @@ type StorageScopeSpec struct {
 	// +nullable
 	// +optional
 	StorageClassDeviceSets []StorageClassDeviceSet `json:"storageClassDeviceSets,omitempty"`
+	// +nullable
+	// +optional
+	Scrubbing Scrubbing `json:"scrubbing"`
 }
 
 // Node is a storage nodes
@@ -2860,4 +2863,74 @@ type ConfigFileVolumeSource struct {
 	ConfigMap *v1.ConfigMapVolumeSource `json:"configMap,omitempty" protobuf:"bytes,19,opt,name=configMap"`
 	// projected items for all in one resources secrets, configmaps, and downward API
 	Projected *v1.ProjectedVolumeSource `json:"projected,omitempty" protobuf:"bytes,26,opt,name=projected"`
+}
+
+type Scrubbing struct {
+	// ApplySchedule whether the scrubbing schedule specified should be applied to the cluster
+	// +optional
+	ApplySchedule bool `json:"applySchedule,omitempty"`
+	// Max scrubbing operations at the same time
+	// +optional
+	// +kubebuilder:default=3
+	// +kubebuilder:validation:Minimum=1
+	MaxScrubOps int64 `json:"maxScrubOps,omitempty"`
+	// Begin hour of scrubbing schedule
+	// Setting both `BeginHour` and `EndHour` to `0`, will allow scrubbing the entire day.
+	// Default: `0`
+	// +optional
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Minimum=0
+	BeginHour int32 `json:"beginHour,omitempty"`
+	// End hour of scrubbing schedule
+	// Default: `0`
+	// +optional
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Minimum=0
+	EndHour int32 `json:"endHour,omitempty"`
+	// Begin week day of scrubbing schedule
+	// `0` = Sunday, `1` = Monday, etc.
+	// Default: `0` = Sunday
+	// +optional
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Minimum=0
+	BeginWeekDay int32 `json:"beginWeekDay,omitempty"`
+	// End week day of scrubbing schedule
+	// `0` = Sunday, `1` = Monday, etc.
+	// Default: `0` = Sunday
+	// +optional
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Minimum=0
+	EndWeekDay int32 `json:"endWeekDay,omitempty"`
+	// Minimum interval to wait before scrubbing again
+	// Default: `24h` (1 day)
+	// Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to
+	// https://github.com/openshift/hive/pull/1684 for showing a way to fix it.
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern=^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+	MinScrubInterval *metav1.Duration `json:"minScrubInterval,omitempty"`
+	// Maximum interval to wait before scrubbing is forced
+	// Default: `168h` (7 days)
+	// Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to
+	// https://github.com/openshift/hive/pull/1684 for showing a way to fix it.
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern=^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+	MaxScrubInterval *metav1.Duration `json:"maxScrubInterval,omitempty"`
+	// Interval at which to do deeb scrubbing instead of a "light" scrubbing
+	// Default: `168h` (7 days)
+	// Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to
+	// https://github.com/openshift/hive/pull/1684 for showing a way to fix it.
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern=^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+	DeepScrubInterval *metav1.Duration `json:"deepScrubInterval,omitempty"`
+	// Set the scrub sleep as a duration
+	// Default `0ms`, recommended if you are impacted by scrubbing `100ms`
+	// Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. Thanks to
+	// https://github.com/openshift/hive/pull/1684 for showing a way to fix it.
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern=^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+	ScrubSleepSeconds *metav1.Duration `json:"scrubSleepSeconds,omitempty"`
 }

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -246,6 +246,10 @@ func (c *Cluster) Start() error {
 		return errors.Wrapf(err, "failed to reconcile key rotation cron jobs")
 	}
 
+	if err := c.ConfigureOSDScrubbing(); err != nil {
+		return errors.Wrap(err, "failed to reconcile osd scrubbing schedule")
+	}
+
 	logger.Infof("finished running OSDs in namespace %q", namespace)
 	return nil
 }

--- a/pkg/operator/ceph/cluster/osd/scrubbing.go
+++ b/pkg/operator/ceph/cluster/osd/scrubbing.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2023 Koor Technolgies, Inc.
+*/
+
+package osd
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/rook/rook/pkg/operator/ceph/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	defaultScrubMinInterval  = 1 * 24 * time.Hour
+	defaultScrubMaxInterval  = 7 * 24 * time.Hour
+	defaultDeepScrubInterval = 7 * 24 * time.Hour
+	defaultScrubSleepSeconds = 0 * time.Second
+)
+
+func (c *Cluster) ConfigureOSDScrubbing() error {
+	if !c.spec.Storage.Scrubbing.ApplySchedule {
+		logger.Info("scrubbing schedule not enabled, skipping setting custom schedule")
+		return nil
+	}
+
+	logger.Debug("applying scrubbing schedule")
+
+	schedule := c.spec.Storage.Scrubbing
+	s := config.GetMonStore(c.context, c.clusterInfo)
+
+	// Max Scrubs
+	if schedule.MaxScrubOps < 1 {
+		schedule.MaxScrubOps = 3
+		logger.Warning("invalid schrubbing max scrub ops set, must be 1 or higher")
+	}
+	if _, err := s.SetIfChanged("osd", "osd_max_scrubs", strconv.Itoa(int(schedule.MaxScrubOps))); err != nil {
+		return err
+	}
+
+	// Hour
+	if _, err := s.SetIfChanged("osd", "osd_scrub_begin_hour", strconv.Itoa(int(schedule.BeginHour))); err != nil {
+		return err
+	}
+	if _, err := s.SetIfChanged("osd", "osd_scrub_end_hour", strconv.Itoa(int(schedule.EndHour))); err != nil {
+		return err
+	}
+
+	// Week Days
+	if _, err := s.SetIfChanged("osd", "osd_scrub_begin_week_day", strconv.Itoa(int(schedule.BeginWeekDay))); err != nil {
+		return err
+	}
+	if _, err := s.SetIfChanged("osd", "osd_scrub_end_week_day", strconv.Itoa(int(schedule.EndWeekDay))); err != nil {
+		return err
+	}
+
+	// Scrub Intervals
+	if schedule.MinScrubInterval == nil || schedule.MinScrubInterval.Duration <= 0 {
+		schedule.MinScrubInterval.Duration = defaultScrubMinInterval
+	}
+	if _, err := s.SetIfChanged("osd", "osd_scrub_min_interval", fmt.Sprintf("%f", schedule.MinScrubInterval.Seconds())); err != nil {
+		return err
+	}
+	if schedule.MaxScrubInterval == nil || schedule.MaxScrubInterval.Duration <= 0 {
+		schedule.MaxScrubInterval.Duration = defaultScrubMaxInterval
+	}
+	if _, err := s.SetIfChanged("osd", "osd_scrub_max_interval", fmt.Sprintf("%f", schedule.MaxScrubInterval.Seconds())); err != nil {
+		return err
+	}
+
+	if schedule.DeepScrubInterval == nil || schedule.DeepScrubInterval.Duration <= 0 {
+		schedule.DeepScrubInterval.Duration = defaultDeepScrubInterval
+	}
+	if _, err := s.SetIfChanged("osd", "osd_deep_scrub_interval", fmt.Sprintf("%f", schedule.DeepScrubInterval.Seconds())); err != nil {
+		return err
+	}
+
+	if schedule.ScrubSleepSeconds == nil || schedule.ScrubSleepSeconds.Duration < 0 {
+		scrubSleepSeconds := 0 * time.Second
+		schedule.ScrubSleepSeconds = &metav1.Duration{
+			Duration: scrubSleepSeconds,
+		}
+	}
+	if _, err := s.SetIfChanged("osd", "osd_scrub_sleep", fmt.Sprintf("%f", schedule.ScrubSleepSeconds.Seconds())); err != nil {
+		return err
+	}
+
+	logger.Info("scrubbing schedule applied if needed")
+
+	return nil
+}

--- a/pkg/operator/ceph/cluster/osd/scrubbing_test.go
+++ b/pkg/operator/ceph/cluster/osd/scrubbing_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright (c) 2023 Koor Technolgies, Inc.
+*/
+
+package osd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/config"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestScrubbingScheduleSetup(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	clientset := fake.NewSimpleClientset()
+	clusterInfo := &cephclient.ClusterInfo{
+		Namespace:   "ns",
+		CephVersion: cephver.Quincy,
+		Context:     context.TODO(),
+		OwnerInfo:   cephclient.NewMinimumOwnerInfoWithOwnerRef(),
+	}
+	ctx := &clusterd.Context{
+		Clientset: clientset,
+		Executor:  executor}
+	spec := cephv1.ClusterSpec{}
+	c := New(ctx, clusterInfo, spec, "myversion")
+	s := config.GetMonStore(ctx, clusterInfo)
+
+	execCount := 0
+	countExecs := true
+	mockStore := map[string]map[string]string{}
+	executor.MockExecuteCommandWithTimeout =
+		func(timeout time.Duration, command string, args ...string) (string, error) {
+			if countExecs {
+				execCount++
+			}
+
+			if args[0] == "config" {
+				if args[1] == "get" {
+					whose, ok := mockStore[args[2]]
+					if !ok {
+						return "", nil
+					}
+
+					val, ok := whose[args[3]]
+					if !ok {
+						return "", nil
+					}
+
+					return val, nil
+				} else if args[1] == "set" {
+					whose, ok := mockStore[args[2]]
+					if !ok {
+						whose = map[string]string{}
+					}
+
+					whose[args[3]] = args[4]
+					mockStore[args[2]] = whose
+
+					return "", nil
+				}
+			}
+
+			return "", nil
+		}
+
+	// No scrubbing schedule given, so no commands are executed
+	err := c.ConfigureOSDScrubbing()
+	assert.Nil(t, err)
+	assert.Equal(t, 0, execCount)
+
+	err = c.ConfigureOSDScrubbing()
+	assert.Nil(t, err)
+	assert.Equal(t, 0, execCount)
+
+	countExecs = false
+	emptyExpect := map[string]string{
+		"osd_max_scrubs":           "",
+		"osd_scrub_begin_hour":     "",
+		"osd_scrub_end_hour":       "",
+		"osd_scrub_begin_week_day": "",
+		"osd_scrub_end_week_day":   "",
+		"osd_scrub_min_interval":   "",
+		"osd_scrub_max_interval":   "",
+		"osd_deep_scrub_interval":  "",
+		"osd_scrub_sleep":          "",
+	}
+	validateConfigStoreContent(t, s, "osd", emptyExpect)
+	countExecs = true
+
+	// Scrubbing schedule is enabled, it should be configured now
+	// Every config option causes 1 get to the config store
+	// Every set causes 1 set to the config store
+	schedule := cephv1.Scrubbing{
+		ApplySchedule:     true,
+		MaxScrubOps:       2,
+		BeginHour:         21,
+		EndHour:           5,
+		BeginWeekDay:      1,
+		EndWeekDay:        5,
+		MinScrubInterval:  &metav1.Duration{Duration: defaultScrubMinInterval},
+		MaxScrubInterval:  &metav1.Duration{Duration: defaultScrubMaxInterval},
+		DeepScrubInterval: &metav1.Duration{Duration: defaultDeepScrubInterval},
+		ScrubSleepSeconds: &metav1.Duration{Duration: defaultScrubSleepSeconds},
+	}
+	c.spec.Storage.Scrubbing = schedule
+	err = c.ConfigureOSDScrubbing()
+	assert.Nil(t, err)
+	assert.Equal(t, 18, execCount)
+
+	err = c.ConfigureOSDScrubbing()
+	assert.Nil(t, err)
+	assert.Equal(t, 27, execCount)
+
+	countExecs = false
+	expected := map[string]string{
+		"osd_max_scrubs":           "2",
+		"osd_scrub_begin_hour":     "21",
+		"osd_scrub_end_hour":       "5",
+		"osd_scrub_begin_week_day": "1",
+		"osd_scrub_end_week_day":   "5",
+		"osd_scrub_min_interval":   "86400.000000",
+		"osd_scrub_max_interval":   "604800.000000",
+		"osd_deep_scrub_interval":  "604800.000000",
+		"osd_scrub_sleep":          "0.000000",
+	}
+	validateConfigStoreContent(t, s, "osd", expected)
+	countExecs = true
+
+	// Disable scrubbing and not changes should occur
+	c.spec.Storage.Scrubbing.ApplySchedule = false
+
+	err = c.ConfigureOSDScrubbing()
+	assert.Nil(t, err)
+	assert.Equal(t, 27, execCount)
+
+	err = c.ConfigureOSDScrubbing()
+	assert.Nil(t, err)
+	assert.Equal(t, 27, execCount)
+
+	// Enable and change a value of the scrubbing schedule
+	c.spec.Storage.Scrubbing.ApplySchedule = true
+	c.spec.Storage.Scrubbing.BeginHour = 1
+	expected["osd_scrub_begin_hour"] = "1"
+	c.spec.Storage.Scrubbing.ScrubSleepSeconds = &metav1.Duration{Duration: 10*time.Second + 500*time.Millisecond}
+	expected["osd_scrub_sleep"] = "10.500000"
+
+	err = c.ConfigureOSDScrubbing()
+	assert.Nil(t, err)
+	assert.Equal(t, 38, execCount)
+
+	err = c.ConfigureOSDScrubbing()
+	assert.Nil(t, err)
+	assert.Equal(t, 47, execCount)
+
+	countExecs = false
+	validateConfigStoreContent(t, s, "osd", expected)
+}
+
+func validateConfigStoreContent(t *testing.T, s *config.MonStore, who string, expected map[string]string) {
+	for key, expect := range expected {
+		val, err := s.Get(who, key)
+		assert.Nil(t, err)
+		assert.Equalf(t, expect, val, "key: %s", key)
+	}
+}


### PR DESCRIPTION
**Description of your changes:**

This implements the OSD Scrubbing schedule design document from #97.

This adds OSD scrubbing schedule config options to the CephCluster CRD for easy configuration instead of having to go through the `rook-config-override` ConfigMap.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [x] **Skip Tests for Docs**: If this is only a documentation change, add the label `skip-ci` on the PR.
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [x] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
